### PR TITLE
Adds flag_name to opts [ES-333]

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Usage: mix coveralls <Options>
     -o (--output-dir)   Write coverage information to output dir.
     -u (--umbrella)     Show overall coverage for umbrella project.
     -v (--verbose)      Show json string for posting.
+    --flagname          coveralls.io 'flag_name' option (See coveralls.io API Reference)
     --subdir            Git repo sub directory: This will be added to the the front of file path, use if your covered
                         file paths reside within a subfolder of the git repo. Example: If your source file path is
                         "test.ex", and your git repo root is one directory up making the file's relative path

--- a/lib/excoveralls/circle.ex
+++ b/lib/excoveralls/circle.ex
@@ -22,7 +22,8 @@ defmodule ExCoveralls.Circle do
       service_pull_request: get_pull_request(),
       source_files: stats,
       git: generate_git_info(),
-      parallel: options[:parallel]
+      parallel: options[:parallel],
+      flag_name: options[:flagname]
     })
   end
 

--- a/lib/excoveralls/drone.ex
+++ b/lib/excoveralls/drone.ex
@@ -22,7 +22,8 @@ defmodule ExCoveralls.Drone do
       service_pull_request: get_pull_request(),
       source_files: stats,
       git: generate_git_info(),
-      parallel: options[:parallel]
+      parallel: options[:parallel],
+      flag_name: options[:flagname]
     })
   end
 

--- a/lib/excoveralls/github.ex
+++ b/lib/excoveralls/github.ex
@@ -22,6 +22,7 @@ defmodule ExCoveralls.Github do
       service_name: "github",
       source_files: stats,
       parallel: options[:parallel],
+      flag_name: options[:flagname],
       git: git_info()
     }
     |> Map.merge(job_data())

--- a/lib/excoveralls/gitlab.ex
+++ b/lib/excoveralls/gitlab.ex
@@ -25,7 +25,8 @@ defmodule ExCoveralls.Gitlab do
       service_pull_request: get_pull_request(),
       source_files: stats,
       git: generate_git_info(),
-      parallel: options[:parallel]
+      parallel: options[:parallel],
+      flag_name: options[:flagname]
     })
   end
 

--- a/lib/excoveralls/post.ex
+++ b/lib/excoveralls/post.ex
@@ -19,6 +19,7 @@ defmodule ExCoveralls.Post do
       service_number: options[:service_number],
       source_files: source_info,
       parallel: options[:parallel],
+      flag_name: options[:flagname],
       git: generate_git_info(options)
     })
   end

--- a/lib/excoveralls/semaphore.ex
+++ b/lib/excoveralls/semaphore.ex
@@ -22,7 +22,8 @@ defmodule ExCoveralls.Semaphore do
       service_pull_request: get_pull_request(),
       source_files: stats,
       git: generate_git_info(),
-      parallel: options[:parallel]
+      parallel: options[:parallel],
+      flag_name: options[:flagname]
     })
   end
 

--- a/lib/excoveralls/task/util.ex
+++ b/lib/excoveralls/task/util.ex
@@ -26,6 +26,7 @@ Usage: mix coveralls <Options>
                         github repo, so must be exact. Example: If your source file path is "/home/runs/app/test.ex",
                         and your git repo resides in "app", then the root path should be: "/home/runs/app/" (from
                         coveralls.io)
+    --flagname          coveralls.io 'flag_name' option (See coveralls.io API Reference)
 
 Usage: mix coveralls.detail [--filter file-name-pattern]
   Used to display coverage with detail

--- a/lib/mix/tasks.ex
+++ b/lib/mix/tasks.ex
@@ -33,7 +33,8 @@ defmodule Mix.Tasks.Coveralls do
         message: "Please specify 'test_coverage: [tool: ExCoveralls]' in the 'project' section of mix.exs"
     end
 
-    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string, output_dir: :string, subdir: :string, rootdir: :string]
+    switches = [filter: :string, umbrella: :boolean, verbose: :boolean, pro: :boolean, parallel: :boolean, sort: :string, output_dir: :string, flagname: :string, subdir: :string, rootdir: :string]
+
     aliases = [f: :filter, u: :umbrella, v: :verbose, o: :output_dir]
     {args, common_options} = parse_common_options(args, switches: switches, aliases: aliases)
     all_options = options ++ common_options
@@ -65,6 +66,7 @@ defmodule Mix.Tasks.Coveralls do
   def parse_common_options(args, common_options) do
     common_switches = Keyword.get(common_options, :switches, [])
     common_aliases = Keyword.get(common_options, :aliases, [])
+
     {common_options, _remaining, _invalid} = OptionParser.parse(args, common_options)
 
     # the switches that excoveralls supports
@@ -272,7 +274,7 @@ defmodule Mix.Tasks.Coveralls do
       aliases = [f: :filter, u: :umbrella, v: :verbose]
       {remaining, options} = Mix.Tasks.Coveralls.parse_common_options(
         args,
-        switches: switches ++ [sha: :string, token: :string, committer: :string, branch: :string, message: :string, name: :string],
+        switches: switches ++ [sha: :string, token: :string, committer: :string, branch: :string, message: :string, name: :string, flagname: :string],
         aliases: aliases ++ [n: :name, b: :branch, c: :committer, m: :message, s: :sha, t: :token]
       )
 
@@ -289,6 +291,7 @@ defmodule Mix.Tasks.Coveralls do
           umbrella:     options[:umbrella],
           verbose:      options[:verbose],
           parallel:     options[:parallel],
+          flag_name:    options[:flagname] || "",
           rootdir:      options[:rootdir] || "",
           subdir:       options[:subdir] || ""
         ])

--- a/test/mix/tasks_test.exs
+++ b/test/mix/tasks_test.exs
@@ -117,6 +117,12 @@ defmodule Mix.Tasks.CoverallsTest do
     assert(ExCoveralls.ConfServer.get == [type: "circle", parallel: true, args: []])
   end
 
+  test_with_mock "circle --parallel --flagname someflag", Runner, [run: fn(_, _) -> nil end] do
+    Mix.Tasks.Coveralls.Circle.run(["--parallel", "--flagname", "someflag"])
+    assert(called Runner.run("test", ["--cover"]))
+    assert(ExCoveralls.ConfServer.get == [type: "circle", parallel: true, flagname: "someflag", args: []])
+  end
+
   test_with_mock "semaphore", Runner, [run: fn(_, _) -> nil end] do
     Mix.Tasks.Coveralls.Semaphore.run([])
     assert(called Runner.run("test", ["--cover"]))
@@ -142,14 +148,14 @@ defmodule Mix.Tasks.CoverallsTest do
     System.put_env("COVERALLS_REPO_TOKEN", "dummy_token")
     System.put_env("COVERALLS_SERVICE_NAME", "dummy_service_name")
 
-    args = ["-b", "branch", "-c", "committer", "-m", "message", "-s", "asdf", "--rootdir", "umbrella0/", "--subdir", "", "--build", "1"]
+    args = ["-b", "branch", "-c", "committer", "-m", "message", "-s", "asdf", "--rootdir", "umbrella0/", "--subdir", "", "--build", "1", "--flagname", "arbitrary_value"]
     Mix.Tasks.Coveralls.Post.run(args)
     assert(called Runner.run("test", ["--cover"]))
     assert(ExCoveralls.ConfServer.get ==
              [type: "post", endpoint: nil, token: "dummy_token",
               service_name: "dummy_service_name", service_number: "1", branch: "branch",
               committer: "committer", sha: "asdf", message: "message",
-              umbrella: nil, verbose: nil, parallel: nil, rootdir: "umbrella0/", subdir: "", args: []])
+              umbrella: nil, verbose: nil, parallel: nil, flag_name: "arbitrary_value", rootdir: "umbrella0/", subdir: "", args: []])
 
     System.put_env("COVERALLS_REPO_TOKEN", org_token)
     System.put_env("COVERALLS_SERVICE_NAME", org_name)
@@ -169,7 +175,7 @@ defmodule Mix.Tasks.CoverallsTest do
              [type: "post", endpoint: nil, token: "token",
               service_name: "excoveralls", service_number: "", branch: "",
               committer: "", sha: "", message: "[no commit message]",
-              umbrella: nil, verbose: nil, parallel: nil, rootdir: "", subdir: "", args: []])
+              umbrella: nil, verbose: nil, parallel: nil, flag_name: "", rootdir: "", subdir: "", args: []])
 
     if org_token != nil do
       System.put_env("COVERALLS_REPO_TOKEN", org_token)

--- a/test/post_test.exs
+++ b/test/post_test.exs
@@ -30,11 +30,12 @@ defmodule ExCoveralls.PostTest do
         branch: "",
         committer: "",
         message: "",
-        sha: ""
+        sha: "",
+        flagname: "arbitrary_value"
       ])
 
     assert json ==
-       "{\"git\":{\"branch\":\"\",\"head\":{\"committer_name\":\"\",\"id\":\"\",\"message\":\"\"}}," <>
+      "{\"flag_name\":\"arbitrary_value\",\"git\":{\"branch\":\"\",\"head\":{\"committer_name\":\"\",\"id\":\"\",\"message\":\"\"}}," <>
          "\"parallel\":null," <>
          "\"repo_token\":\"1234567890\"," <>
          "\"service_name\":\"local\"," <>


### PR DESCRIPTION
## What's here?

- We want to pass `flag_name` to coveralls.io via this library

## Milestones

- [x] Add flag_name to opts
- [x] Tests

## Usage samples

- Via Post

<img width="1724" alt="image" src="https://user-images.githubusercontent.com/6396347/193006563-1fbaf1db-4c59-48b3-9aad-bcf69c01c1e1.png">

<img width="957" alt="image" src="https://user-images.githubusercontent.com/6396347/193006818-b4b21a94-162b-4b9c-907c-310645adab8d.png">


- Via Circle CI

<img width="583" alt="image" src="https://user-images.githubusercontent.com/6396347/193008766-899fd401-606f-483c-9f59-d14fae34a71b.png">


<img width="1391" alt="image" src="https://user-images.githubusercontent.com/6396347/193008669-64048b7d-8db4-4768-abd7-abcd7797b66c.png">

- Via Circle CI **without flagname**

<img width="1264" alt="image" src="https://user-images.githubusercontent.com/6396347/193009180-753d61ec-f815-498c-b912-3e7ac2653736.png">


## References

- https://duffel.atlassian.net/browse/ES-333